### PR TITLE
Add FortanLang in official language docs 

### DIFF
--- a/Documentaciones/docs.html
+++ b/Documentaciones/docs.html
@@ -630,6 +630,16 @@ const documentationsData = [
   iconColor: "linear-gradient(135deg, #9558B2 0%, #389826 100%)",
   link: "https://docs.julialang.org/en/v1/",
   version: "1.9"
+},
+{
+  id: 40,
+  title: "Fortran",
+  description: "Fortran es un lenguaje de programación de alto nivel. Su nombre viene de FORmula TRANslation, porque fue diseñado originalmente para facilitar el cálculo numérico y científico, traduciendo fórmulas matemáticas en programas que pudieran ejecutarse en ordenadores.",
+  category: "otro",
+  icon: "fas fa-code",
+  iconColor: "linear-gradient(135deg, #6c3b2a 0%, #9558B2 100%)",
+  link: "https://fortran-lang.org/",
+  version: "0.7.0"
 }
 
 


### PR DESCRIPTION
# Changes
- Add **FortanLang**

# Code 
``` js
id: 40,
  title: "Fortran",
  description: "Fortran es un lenguaje de programación de alto nivel. Su nombre viene de FORmula TRANslation, porque fue diseñado originalmente para facilitar el cálculo numérico y científico, traduciendo fórmulas matemáticas en programas que pudieran ejecutarse en ordenadores.",
  category: "otro",
  icon: "fas fa-code",
  iconColor: "linear-gradient(135deg, #6c3b2a 0%, #9558B2 100%)",
  link: "https://fortran-lang.org/",
  version: "0.7.0"
  ```